### PR TITLE
fix: use valid scrollIntoView behavior

### DIFF
--- a/src/components/custom/use-scroll-to-bottom.ts
+++ b/src/components/custom/use-scroll-to-bottom.ts
@@ -13,7 +13,7 @@ export function useScrollToBottom<T extends HTMLElement>(): [
 
     if (container && end) {
       const observer = new MutationObserver(() => {
-        end.scrollIntoView({ behavior: 'instant', block: 'end' });
+        end.scrollIntoView({ behavior: 'auto', block: 'end' });
       });
 
       observer.observe(container, {


### PR DESCRIPTION
## Summary
- ensure scrollToBottom hook uses standard `auto` behavior

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*